### PR TITLE
Add tag to snyk container image

### DIFF
--- a/build/ci.mk
+++ b/build/ci.mk
@@ -42,7 +42,7 @@ ci/snyk-test:
 			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e SNYK_TOKEN \
-			snyk/snyk:golang snyk test --severity-threshold=high
+			snyk/snyk:golang-1.15 snyk test --severity-threshold=high
 
 .PHONY : ci/build
 ci/build: ci/deps


### PR DESCRIPTION
Snyk started to fail recently if using the latest tag. 1.15 seems to work