### PR TITLE
Pipeline refactor

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: "path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
+          go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
       - name: Running unit tests
         shell: pwsh
         run: |
@@ -73,7 +73,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: "path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
+          go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
       - name: Integration test
         env:
           GOPATH: ${{ github.workspace }}
@@ -131,7 +131,8 @@ jobs:
       - name: Download zip from GH Release assets and extract .exe
         shell: pwsh
         run: |
-          build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\download_zip.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
       - name: Create MSI
         shell: pwsh
         run: |

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
   INTEGRATION: "haproxy"
@@ -93,7 +94,6 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
-
   test-build-nix:
     name: Test binary compilation and packaging for linux
     runs-on: ubuntu-latest
@@ -103,7 +103,11 @@ jobs:
       GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
       - uses: actions/checkout@v3
-      - run: git tag "$TAG"
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
       - name: Build all platforms:arch
         run: make ci/fake-prerelease
       - name: Upload artifacts for next job
@@ -144,7 +148,12 @@ jobs:
 
       - name: Get PFX certificate from GH secrets
         shell: bash
-        run: printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+        run: |
+          if [ -z "$PFX_CERTIFICATE_BASE64" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          else
+            printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+          fi
       - name: Extract .exe
         shell: pwsh
         run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
 
 env:
-  TAG: "v0.0.0" # needed for goreleaser windows builds
+  INTEGRATION: "haproxy"
+  ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  ORIGINAL_REPO_NAME: "newrelic/nri-haproxy"
-  DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+  TAG: "v1.2.3" # needed for fake-prereleases
 
 jobs:
   static-analysis:
@@ -93,10 +93,61 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
-  test-build:
-    name: Test binary compilation for all platforms:arch
+
+  test-build-nix:
+    name: Test binary compilation and packaging for linux
     runs-on: ubuntu-latest
+    env:
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
       - uses: actions/checkout@v3
+      - run: git tag "$TAG"
       - name: Build all platforms:arch
-        run: make ci/build
+        run: make ci/fake-prerelease
+      - name: Upload artifacts for next job
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-packages
+          path: dist/nri-*.zip
+
+  test-build-windows:
+    name: Create MSI
+    runs-on: windows-latest
+    needs: [test-build-nix]
+    env:
+      GOPATH: ${{ github.workspace }}
+      PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
+      PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
+      PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
+    defaults:
+      run:
+        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    strategy:
+      matrix:
+        goarch: [amd64,386]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+      - shell: bash
+        run: git tag "$TAG"
+
+      - name: Download artifact from previous job
+        if: needs.docker-build.result != 'skipped'
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-packages
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
+
+      - name: Get PFX certificate from GH secrets
+        shell: bash
+        run: printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+      - name: Extract .exe
+        shell: pwsh
+        run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+      - name: Create MSI
+        shell: pwsh
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -52,8 +52,8 @@ else
 	exit 1
 endif
 
-.PHONY : ci/prerelease
-ci/prerelease: ci/deps
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
 ifdef TAG
 	@docker run --rm -t \
 			--name "nri-$(INTEGRATION)-prerelease" \
@@ -70,5 +70,27 @@ ifdef TAG
 			$(BUILDER_TAG) make release
 else
 	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
+	exit 1
+endif
+
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
+ifdef TAG
+	@docker run --rm -t \
+			--name "nri-$(INTEGRATION)-prerelease" \
+			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-e INTEGRATION \
+			-e PRERELEASE=true \
+			-e NO_PUBLISH=true \
+			-e GITHUB_TOKEN \
+			-e REPO_FULL_NAME \
+			-e TAG \
+			-e GPG_MAIL \
+			-e GPG_PASSPHRASE \
+			-e GPG_PRIVATE_KEY_BASE64 \
+			$(BUILDER_TAG) make release
+else
+	@echo "===> $(INTEGRATION) ===  [ci/fake-prerelease] TAG env variable expected to be set"
 	exit 1
 endif

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -83,6 +83,7 @@ ifdef TAG
 			-e INTEGRATION \
 			-e PRERELEASE=true \
 			-e NO_PUBLISH=true \
+			-e NO_SIGN \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -52,8 +52,8 @@ else
 	exit 1
 endif
 
-.PHONY : ci/fake-prerelease
-ci/fake-prerelease: ci/deps
+.PHONY : ci/prerelease
+ci/prerelease: ci/deps
 ifdef TAG
 	@docker run --rm -t \
 			--name "nri-$(INTEGRATION)-prerelease" \

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-386</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-amd64</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/release.mk
+++ b/build/release.mk
@@ -42,14 +42,21 @@ release/fix-archive:
 
 .PHONY : release/sign/nix
 release/sign/nix:
+ifneq ($(NO_SIGN), true)
 	@echo "===> $(INTEGRATION) === [release/sign] signing packages"
 	@bash $(CURDIR)/build/nix/sign.sh
-
+else
+	@echo "===> $(INTEGRATION) === [release/sign] signing packages is disabled by environment variable"
+endif
 
 .PHONY : release/publish
 release/publish:
+ifneq ($(NO_PUBLISH), true)
 	@echo "===> $(INTEGRATION) === [release/publish] publishing artifacts"
 	@bash $(CURDIR)/build/upload_artifacts_gh.sh
+else
+	@echo "===> $(INTEGRATION) === [release/publish] publish is disabled by environment variable"
+endif
 
 .PHONY : release
 release: release/build release/fix-archive release/sign/nix release/publish release/clean

--- a/build/windows/download_zip.ps1
+++ b/build/windows/download_zip.ps1
@@ -5,15 +5,12 @@ param (
     [string]$REPO_FULL_NAME="none"
 )
 write-host "===> Creating dist folder"
-New-Item -ItemType directory -Path .\dist
+New-Item -ItemType directory -Path .\dist -Force
 
 $VERSION=${TAG}.substring(1)
-$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
 $zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
 
 $zip_url="https://github.com/${REPO_FULL_NAME}/releases/download/${TAG}/${zip_name}"
 write-host "===> Downloading & extracting .exe from ${zip_url}"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest "${zip_url}" -OutFile ".\dist\${zip_name}"
-write-host "===> Expanding"
-expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/extract_exe.ps1
+++ b/build/windows/extract_exe.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$INTEGRATION="none",
+    [string]$ARCH="amd64",
+    [string]$TAG="v0.0.0"
+)
+write-host "===> Creating dist folder"
+New-Item -ItemType directory -Path .\dist -Force
+
+$VERSION=${TAG}.substring(1)
+$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
+$zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
+
+write-host "===> Expanding"
+expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/package_msi.ps1
+++ b/build/windows/package_msi.ps1
@@ -30,11 +30,16 @@ if ($wrong.Length  -ne 0) {
     exit -1
 }
 
-echo "===> Import .pfx certificate from GH Secrets"
-Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
+$noSign = $env:NO_SIGN ?? "false"
+if ($noSign -ieq "true") {
+    echo "===> Import .pfx certificate is disabled by environment variable"
+} else {
+    echo "===> Import .pfx certificate from GH Secrets"
+    Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
 
-echo "===> Show certificate installed"
-Get-ChildItem -Path cert:\CurrentUser\My\
+    echo "===> Show certificate installed"
+    Get-ChildItem -Path cert:\CurrentUser\My\
+}
 
 echo "===> Checking MSBuild.exe..."
 $msBuild = (Get-ItemProperty hklm:\software\Microsoft\MSBuild\ToolsVersions\4.0).MSBuildToolsPath
@@ -47,7 +52,7 @@ echo $msBuild
 echo "===> Building Installer"
 Push-Location -Path "build\package\windows\nri-$arch-installer"
 
-. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:pfx_certificate_description=$pfx_certificate_description
+. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:NoSign=$noSign /p:pfx_certificate_description=$pfx_certificate_description
 
 if (-not $?)
 {


### PR DESCRIPTION
We are not testing packaging at PR time. This PR adds `fake-prerelease` target to the makefile that does exactly the same as `prerelease` without uploading the artifacts to GitHub.

This should be enough to test that the packages are correctly created in both operative systems.
