### PR TITLE
[NR-191065] chore: bump haproxy testing version to 3.0

### DIFF
--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   haproxy:
-    image: haproxy:2.9
+    image: haproxy:3.0
     restart: always
     ports:
     - "8404:8404"


### PR DESCRIPTION
Bumps haproxy testing version to 3.0