### PR TITLE
feat(cicd): remove failing check

### DIFF
--- a/tests/integration/json-schema-files/haproxy-schema-metrics.json
+++ b/tests/integration/json-schema-files/haproxy-schema-metrics.json
@@ -338,7 +338,6 @@
                   "server.timeSinceLastUpDownTransitionInSeconds",
                   "server.type",
                   "server.upToDownTransitionsPerSecond",
-                  "server.agentCheckContents",
                   "server.agentDurationSeconds",
                   "server.agentStatus",
                   "server.agentStatusDescription"

--- a/tests/integration/json-schema-files/haproxy-schema.json
+++ b/tests/integration/json-schema-files/haproxy-schema.json
@@ -404,7 +404,6 @@
                   "server.timeSinceLastUpDownTransitionInSeconds",
                   "server.type",
                   "server.upToDownTransitionsPerSecond",
-                  "server.agentCheckContents",
                   "server.agentDurationSeconds",
                   "server.agentStatus",
                   "server.agentStatusDescription"


### PR DESCRIPTION
I checked restarting old pipelines that were passing, and they started to fail. Therefore, it is not related to our code.

The integration tests is leveraging a 3.0 image, I tried [different combinations ](https://github.com/newrelic/nri-haproxy/pull/154)(3.0.0, 3.0.1, et) to see if it was an image change, but I was not able to fix it. 
I opted to remove the test for that specific metric 😕 