### PR TITLE
Added new version inside CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ### ⛓️ Dependencies
 - Updated golang patch version to v1.25.7
 
-
 ## v3.2.6 - 2026-02-10
 
 ### ⛓️ Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+## v3.2.7 - 2026-02-17
+
+### ⛓️ Dependencies
+- Updated golang patch version to v1.25.7
+
+
 ## v3.2.6 - 2026-02-10
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
The previous pre-release failed. To address this, we are creating a new pre-release with the latest tag. The new version will be listed under "Unreleased" in the CHANGELOG.md.