### PR TITLE
fix: upgrade go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+
+### security
+- update go to v1.25.9
 ## v3.3.0 - 2026-03-27
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-haproxy
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-bookworm as builder
+FROM golang:1.25.9-bookworm as builder
 ARG CGO_ENABLED=0
 WORKDIR /go/src/github.com/newrelic/nri-haproxy
 COPY . .


### PR DESCRIPTION
## Summary
- Update Go to v1.25.9
- Update `tests/integration/Dockerfile` to use `golang:1.25.9-bookworm`
- Run `go mod tidy` to update dependencies
- Update CHANGELOG.md with security entry

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)